### PR TITLE
#23, #22 #25 Update with EST and eliminate duplicate enrollment grades

### DIFF
--- a/ipe_process_orchestrator/assign_competencies.py
+++ b/ipe_process_orchestrator/assign_competencies.py
@@ -53,9 +53,9 @@ class IPECompetenciesAssigner:
             student_list_payload = page_info
             page_num += 1
       
-      student_grade_with_out_duplicates = pd.DataFrame(students_with_grades).drop_duplicates(subset='student_canvas_id').to_dict('records')
-      logger.info(f"""{len(student_grade_with_out_duplicates)} active enrolled students may receive IPE competencies in the course {self.course[COL_COURSE_ID]}{'. 0 students received competencies.' if len(student_grade_with_out_duplicates)==0 else '.'} """)
-      return student_grade_with_out_duplicates
+      students_grades_no_duplicates = pd.DataFrame(students_with_grades).drop_duplicates(subset='student_canvas_id').to_dict('records')
+      logger.info(f"{len(students_grades_no_duplicates)} active enrolled students may receive IPE competencies in the course {self.course[COL_COURSE_ID]}.")
+      return students_grades_no_duplicates
       
     def get_competency_payload(self) -> Dict[str, Any]:
       competency_payload: Dict[str, Any] = dict()
@@ -131,6 +131,7 @@ class IPECompetenciesAssigner:
       start_time = time.perf_counter()
       student_grades: List[Dict[str, Any]] = self.get_student_list_with_course_grades()
       if(len(student_grades) == 0):
+        logger.info('0 students received competencies.')
         return
       self.assign_competancies(student_grades)
       end_time = time.perf_counter()

--- a/ipe_process_orchestrator/assign_competencies.py
+++ b/ipe_process_orchestrator/assign_competencies.py
@@ -52,8 +52,10 @@ class IPECompetenciesAssigner:
             logging.debug(f'Params for next page: {page_info}')
             student_list_payload = page_info
             page_num += 1
-      logger.info(f'{len(students_with_grades)} active enrolled students may receive IPE competencies in the course {self.course[COL_COURSE_ID]}')
-      return students_with_grades
+      
+      student_grade_with_out_duplicates = pd.DataFrame(students_with_grades).drop_duplicates(subset='student_canvas_id').to_dict('records')
+      logger.info(f'{len(student_grade_with_out_duplicates)} active enrolled students may receive IPE competencies in the course {self.course[COL_COURSE_ID]}')
+      return student_grade_with_out_duplicates
       
     def get_competency_payload(self) -> Dict[str, Any]:
       competency_payload: Dict[str, Any] = dict()

--- a/ipe_process_orchestrator/assign_competencies.py
+++ b/ipe_process_orchestrator/assign_competencies.py
@@ -54,7 +54,7 @@ class IPECompetenciesAssigner:
             page_num += 1
       
       student_grade_with_out_duplicates = pd.DataFrame(students_with_grades).drop_duplicates(subset='student_canvas_id').to_dict('records')
-      logger.info(f'{len(student_grade_with_out_duplicates)} active enrolled students may receive IPE competencies in the course {self.course[COL_COURSE_ID]}')
+      logger.info(f"""{len(student_grade_with_out_duplicates)} active enrolled students may receive IPE competencies in the course {self.course[COL_COURSE_ID]}{'. 0 students received competencies.' if len(student_grade_with_out_duplicates)==0 else '.'} """)
       return student_grade_with_out_duplicates
       
     def get_competency_payload(self) -> Dict[str, Any]:

--- a/ipe_utils/df_utils.py
+++ b/ipe_utils/df_utils.py
@@ -2,6 +2,7 @@ import pandas as pd
 from datetime import datetime
 from constants import (WHEN_TO_RUN_SCRIPT, SCRIPT_RUN, COL_COURSE_ID)
 import logging
+from pytz import timezone
 
 logger = logging.getLogger(__name__)
 
@@ -37,4 +38,5 @@ def current_time()-> str:
     """
     Return current time in format: YYYY-MM-DD HH:MM:SS
     """
-    return datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+    est = timezone('US/Eastern')
+    return datetime.now(est).strftime('%Y-%m-%d %H:%M:%S')

--- a/tests/fixtures/competencies_data.py
+++ b/tests/fixtures/competencies_data.py
@@ -63,3 +63,9 @@ def enrollment_response():
   with open('tests/fixtures/json/enrollment_response.json','r') as f:
         enrollment_json = json.loads(f.read())
   return enrollment_json
+
+@pytest.fixture
+def enrollment_response_with_duplicates():
+  with open('tests/fixtures/json/enrollment_response_with_duplicates.json','r') as f:
+        enrollment_dup_json = json.loads(f.read())
+  return enrollment_dup_json

--- a/tests/fixtures/json/enrollment_response_with_duplicates.json
+++ b/tests/fixtures/json/enrollment_response_with_duplicates.json
@@ -1,0 +1,233 @@
+[
+  {
+    "course_id": 429487,
+    "id": 6323931,
+    "user_id": 151,
+    "course_section_id": 486513,
+    "root_account_id": 1,
+    "type": "StudentEnrollment",
+    "limit_privileges_to_course_section": false,
+    "enrollment_state": "active",
+    "role": "StudentEnrollment",
+    "grades": {
+      "current_grade": null,
+      "current_score": 100.0,
+      "final_grade": null,
+      "final_score": 94.12
+    },
+    "user": {
+      "id": 151,
+      "name": "Student, 1"
+    }
+  },
+  {
+    "course_id": 429487,
+    "id": 6323932,
+    "user_id": 152,
+    "course_section_id": 486513,
+    "root_account_id": 1,
+    "type": "StudentEnrollment",
+    "limit_privileges_to_course_section": false,
+    "enrollment_state": "active",
+    "role": "StudentEnrollment",
+    "grades": {
+      "current_grade": null,
+      "current_score": 100.0,
+      "final_grade": null,
+      "final_score": 64.12
+    },
+    "user": {
+      "id": 152,
+      "name": "Student, 2"
+    }
+  },
+  {
+    "course_id": 429487,
+    "id": 6323933,
+    "user_id": 153,
+    "course_section_id": 486513,
+    "root_account_id": 1,
+    "type": "StudentEnrollment",
+    "limit_privileges_to_course_section": false,
+    "enrollment_state": "active",
+    "role": "StudentEnrollment",
+    "grades": {
+      "current_grade": null,
+      "current_score": 100.0,
+      "final_grade": null,
+      "final_score": 74.12
+    },
+    "user": {
+      "id": 153,
+      "name": "Student, 3"
+    }
+  },
+  {
+    "course_id": 429487,
+    "id": 6323934,
+    "user_id": 154,
+    "course_section_id": 486513,
+    "root_account_id": 1,
+    "type": "StudentEnrollment",
+    "limit_privileges_to_course_section": false,
+    "enrollment_state": "active",
+    "role": "StudentEnrollment",
+    "grades": {
+      "current_grade": null,
+      "current_score": 100.0,
+      "final_grade": null,
+      "final_score": 80.12
+    },
+    "user": {
+      "id": 154,
+      "name": "Student, 4"
+    }
+  },
+  {
+    "course_id": 429487,
+    "id": 6323935,
+    "user_id": 155,
+    "course_section_id": 486513,
+    "root_account_id": 1,
+    "type": "StudentEnrollment",
+    "limit_privileges_to_course_section": false,
+    "enrollment_state": "active",
+    "role": "StudentEnrollment",
+    "grades": {
+      "current_grade": null,
+      "current_score": 100.0,
+      "final_grade": null,
+      "final_score": 60.12
+    },
+    "user": {
+      "id": 155,
+      "name": "Student, 5"
+    }
+  },
+  {
+    "course_id": 429487,
+    "id": 6323936,
+    "user_id": 156,
+    "course_section_id": 486513,
+    "root_account_id": 1,
+    "type": "StudentEnrollment",
+    "limit_privileges_to_course_section": false,
+    "enrollment_state": "active",
+    "role": "StudentEnrollment",
+    "grades": {
+      "current_grade": null,
+      "current_score": 100.0,
+      "final_grade": null,
+      "final_score": 80.12
+    },
+    "user": {
+      "id": 156,
+      "name": "Student, 6"
+    }
+  },
+  {
+    "course_id": 429487,
+    "id": 6323937,
+    "user_id": 157,
+    "course_section_id": 486513,
+    "root_account_id": 1,
+    "type": "StudentEnrollment",
+    "limit_privileges_to_course_section": false,
+    "enrollment_state": "active",
+    "role": "StudentEnrollment",
+    "grades": {
+      "current_grade": null,
+      "current_score": 100.0,
+      "final_grade": null,
+      "final_score": 77.12
+    },
+    "user": {
+      "id": 157,
+      "name": "Student, 7"
+    }
+  },
+  {
+    "course_id": 429487,
+    "id": 6323938,
+    "user_id": 158,
+    "course_section_id": 486513,
+    "root_account_id": 1,
+    "type": "StudentEnrollment",
+    "limit_privileges_to_course_section": false,
+    "enrollment_state": "active",
+    "role": "StudentEnrollment",
+    "grades": {
+      "current_grade": null,
+      "current_score": 100.0,
+      "final_grade": null,
+      "final_score": 98.12
+    },
+    "user": {
+      "id": 158,
+      "name": "Student, 8"
+    }
+  },
+  {
+    "course_id": 429487,
+    "id": 6323939,
+    "user_id": 159,
+    "course_section_id": 486513,
+    "root_account_id": 1,
+    "type": "StudentEnrollment",
+    "limit_privileges_to_course_section": false,
+    "enrollment_state": "active",
+    "role": "StudentEnrollment",
+    "grades": {
+      "current_grade": null,
+      "current_score": 100.0,
+      "final_grade": null,
+      "final_score": 45.12
+    },
+    "user": {
+      "id": 159,
+      "name": "Student, 9"
+    }
+  },
+  {
+    "course_id": 429487,
+    "id": 6323940,
+    "user_id": 160,
+    "course_section_id": 486513,
+    "root_account_id": 1,
+    "type": "StudentEnrollment",
+    "limit_privileges_to_course_section": false,
+    "enrollment_state": "active",
+    "role": "StudentEnrollment",
+    "grades": {
+      "current_grade": null,
+      "current_score": 100.0,
+      "final_grade": null,
+      "final_score": 70.12
+    },
+    "user": {
+      "id": 160,
+      "name": "Student, 10"
+    }
+  },
+  {
+    "course_id": 429487,
+    "id": 6323941,
+    "user_id": 160,
+    "course_section_id": 486514,
+    "root_account_id": 1,
+    "type": "StudentEnrollment",
+    "limit_privileges_to_course_section": false,
+    "enrollment_state": "active",
+    "role": "StudentEnrollment",
+    "grades": {
+      "current_grade": null,
+      "current_score": 100.0,
+      "final_grade": null,
+      "final_score": 70.12
+    },
+    "user": {
+      "id": 160,
+      "name": "Student Sec, 10"
+    }
+  }
+]


### PR DESCRIPTION
Fixes #22 #23 #25
Please use the configuration file from here https://www.dropbox.com/home/TL%20Security%20files/IPE%20Process

I have configured the run for this spread sheet https://docs.google.com/spreadsheets/d/18mtjJ8RRP5MnSQYqzhJtwVBmdkFPy3m0u_i_Rkmuk0A/edit#gid=0

Also move the `.env` file to `/secrets/ipe/` in the same location as Google service account
I created a [new service account](https://console.cloud.google.com/iam-admin/serviceaccounts?project=its-ipe-collab&pli=1) based on the recommendation by ITS GCP team.  so use the non-prod SC for testing. 